### PR TITLE
Fix example command to generate the views manually

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -77,7 +77,7 @@ The plotting utilities of :mod:`Bootstrap` are included in `bootstrap/views <htt
 
 .. code-block:: bash
 
-    python -m bootstrap.views.view
+    python -m bootstrap.views.generate
            -o logs/mnist/sgd/options.yaml
     open logs/mnist/sgd/view.html
 


### PR DESCRIPTION
Running the current command in the doc fails with " No module named bootstrap.views.view"