### PR TITLE
is_best to return True after first epoch

### DIFF
--- a/bootstrap/engines/engine.py
+++ b/bootstrap/engines/engine.py
@@ -359,6 +359,7 @@ class Engine(object):
 
         if name not in self.best_out:
             self.best_out[name] = out[name]
+            return True
         else:
             if eval('{} {} {}'.format(out[name], order, self.best_out[name])):
                 self.best_out[name] = out[name]


### PR DESCRIPTION
Prior to this change, is_best returned false after first epoch.
If the first stayed best, no checkpoint was saved afterwards.
