### PR TITLE
Fix bug in setitem of OptionsDict

### DIFF
--- a/bootstrap/lib/options.py
+++ b/bootstrap/lib/options.py
@@ -51,11 +51,10 @@ class OptionsDict(OrderedDict):
                 val = OptionsDict(val)
                 OrderedDict.__setitem__(self, key, val)
             elif isinstance(key, str) and '.' in key:
-                keys = key.split('.')
-                d = self[keys[0]]
-                for k in keys[1:-1]:
-                    d = d[k]
-                d[keys[-1]] = val
+                first_key, other_keys = key.split('.', maxsplit=1)
+                if first_key not in self:
+                    self[first_key] = OptionsDict({})
+                self[first_key][other_keys] = val
             else:
                 OrderedDict.__setitem__(self, key, val)
         else:
@@ -188,7 +187,7 @@ class Options(object):
 
                     position = Options.__instance.options
                     for piece in nametree[:-1]:
-                        if piece in position and isinstance(position[piece], collections.Mapping):
+                        if piece in position and isinstance(position[piece], collections.abc.Mapping):
                             position = position[piece]
                         else:
                             position[piece] = {}

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -425,6 +425,46 @@ def test_setitem_2():
     assert Options()['model.criterion'] == 'new value'
 
 
+def test_setitem_3():
+    reset_options_instance()
+    source = {'dataset': 123}
+    Options(source, run_parser=False)
+    Options()['model.criterion'] = 'I am a criterion'
+    Options()['model.network'] = 'I am a network'
+    assert Options().options == {
+        'dataset': 123,
+        'model': {
+            'criterion': 'I am a criterion',
+            'network': 'I am a network',
+        },
+    }
+    assert Options()['model.criterion'] == 'I am a criterion'
+    assert Options()['model.network'] == 'I am a network'
+
+
+def test_setitem_4():
+    reset_options_instance()
+    source = {
+        'model.name': 'model',
+    }
+    Options(source, run_parser=False)
+    Options()['model.topk'] = [1, 2]
+    Options()['model.network.input_size'] = 12
+    Options()['model.network.output_size'] = 4
+    Options()['dataset.dataloader.batch_size'] = 8
+    assert Options().options == {
+        'dataset': {'dataloader': {'batch_size': 8}},
+        'model': {
+            'name': 'model',
+            'topk': [1, 2],
+            'network': {
+                'input_size': 12,
+                'output_size': 4
+            }
+        },
+    }
+
+
 def test_setitem_key_int():
     reset_options_instance()
     source = {1: 123}


### PR DESCRIPTION
- The setitem of `OptionDict` was failing when it is used to initialise a nested key. 
For example, if the `OptionDict` `opt` is initialised with `{'model': {'name': 'fc'}}`,
the command `opt['model.network.input_size']` will fail because the dict associated to network is not initialised.

- Replace `collections.Mapping` by `collections.abc.Mapping` to fix the deprecation warning