### PR TITLE
Replace os.system calls with python functions

### DIFF
--- a/bootstrap/run.py
+++ b/bootstrap/run.py
@@ -1,6 +1,7 @@
 import io
 import os
 import sys
+import shutil
 import click
 import torch
 import traceback
@@ -19,13 +20,13 @@ from . import views
 def init_experiment_directory(exp_dir, resume=None):
     # create the experiment directory
     if not os.path.isdir(exp_dir):
-        os.system('mkdir -p ' + exp_dir)
+        os.makedirs(exp_dir)
     else:
         if resume is None:
             if click.confirm('Exp directory already exists in {}. Erase?'
                     .format(exp_dir, default=False)):
-                os.system('rm -r ' + exp_dir)
-                os.system('mkdir -p ' + exp_dir)
+                shutil.rmtree(exp_dir)
+                os.makedirs(exp_dir)
             else:
                 os._exit(1)
 


### PR DESCRIPTION
The code handling the log directories creation/deletion in `bootstrap.run` uses raw  `os.system` calls to `rm` and `mkdir`. Pretty sure this can be dangerous with malformed inputs.