### PR TITLE
Improve bootstrap.run help

### DIFF
--- a/bootstrap/lib/options.py
+++ b/bootstrap/lib/options.py
@@ -165,8 +165,11 @@ class Options(object):
                 self.source = source
             else:
                 # Parsing only the path_opts argument to find yaml file
-                optfile_parser = argparse.ArgumentParser(add_help=False)
+                optfile_parser = argparse.ArgumentParser(add_help=True)
                 optfile_parser.add_argument('-o', '--path_opts', type=str, required=True)
+                if len(sys.argv) == 1:
+                    optfile_parser.print_help(sys.stderr)
+                    os._exit(1)
                 self.source = optfile_parser.parse_known_args()[0].path_opts
 
             options_dict = Options.load_yaml_opts(self.source)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -11,13 +11,12 @@ from bootstrap.lib.options import Options
 from bootstrap.lib.options import OptionsDict
 from bootstrap.lib.utils import merge_dictionaries
 
-
 def reset_options_instance():
     Options._Options__instance = None
     sys.argv = [sys.argv[0]]  # reset command line args
 
 
-def test_empty_path():
+def test_empty_path(monkeypatch):
     """ Test empty path
   
         Expected behavior:
@@ -28,6 +27,9 @@ def test_empty_path():
                 test_options.py: error: the following arguments are required: -o/--path_opts
     """
     reset_options_instance()
+
+    monkeypatch.setattr(os, '_exit', sys.exit)
+
     try:
         Options()
         assert False


### PR DESCRIPTION
Currently, when `bootstrap.run` is called without any options, an exception is raised and logged. Using the help flags '-h/--help' without specifying the '-o/--path_opts' options also crashes.

This PR fixes `bootstrap.run -h/--help` to display the program usage. When `bootstrap.run` is called without any options the program now exists with the error code 1 and prints the usage on stderr.