### PR TITLE
Set exit code to 1 when the execution ends with an exception

### DIFF
--- a/bootstrap/run.py
+++ b/bootstrap/run.py
@@ -185,13 +185,13 @@ def main(path_opts=None, run=None):
         if e.code != 0:
             # to avoid traceback for -h flag in arguments line
             Logger()(traceback.format_exc(), log_level=Logger.ERROR, raise_error=False)
-        raise
+        sys.exit(e.code)
     except KeyboardInterrupt:
         Logger()(traceback.format_exc(), log_level=Logger.ERROR, raise_error=False)
         Logger()('KeyboardInterrupt signal received. Exiting...', log_level=Logger.ERROR, raise_error=False)
-        raise
+        sys.exit(1)
     except Options.MissingOptionsException:
-        raise
+        sys.exit(1)
     except Exception:
         # to be able to write the error trace to exp_dir/logs.txt
         try:
@@ -201,7 +201,7 @@ def main(path_opts=None, run=None):
             print(traceback.format_exc())
             pass
         process_debugger()
-        raise
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/bootstrap/run.py
+++ b/bootstrap/run.py
@@ -185,12 +185,13 @@ def main(path_opts=None, run=None):
         if e.code != 0:
             # to avoid traceback for -h flag in arguments line
             Logger()(traceback.format_exc(), log_level=Logger.ERROR, raise_error=False)
-        pass
+        raise
     except KeyboardInterrupt:
         Logger()(traceback.format_exc(), log_level=Logger.ERROR, raise_error=False)
         Logger()('KeyboardInterrupt signal received. Exiting...', log_level=Logger.ERROR, raise_error=False)
+        raise
     except Options.MissingOptionsException:
-        pass
+        raise
     except Exception:
         # to be able to write the error trace to exp_dir/logs.txt
         try:
@@ -200,6 +201,7 @@ def main(path_opts=None, run=None):
             print(traceback.format_exc())
             pass
         process_debugger()
+        raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is important to keep the correct error code at the end of the job. Some job managers like slurm check the error code to save the job's final status. So job shows up as COMPLETED when it should be displayed as FAILED.
